### PR TITLE
投稿機能が機能する場合はフォールバックするように調整

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func main() {
 		log.Println("Attempting fallback to noop summarizer...")
 		summarizerRepo, err = llm.NewSummarizerRepository(ctx, llm.Config{Provider: "noop"})
 		if err != nil {
-			log.Printf("Warning: noop summarizer initialization failed: %v", err)
+			log.Printf("Warning: noop summarizer initialization failed unexpectedly: %v", err)
 			log.Println("Continuing without summarization feature")
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -47,20 +47,25 @@ func main() {
 	var cacheCloser io.Closer
 	var cacheCleaner cacheWithCleanup
 	firstRunLatestOnly := cfg.FirstRunLatestOnly
+
 	if cfg.IsPersistentCache() {
 		sqliteCache, cacheErr := storage.NewSQLiteCacheRepository(cfg.CacheDBPath)
-		if cacheErr != nil {
-			log.Fatal("Failed to initialize SQLite cache:", cacheErr)
+		if cacheErr == nil {
+			cacheRepo = sqliteCache
+			if closer, ok := sqliteCache.(io.Closer); ok {
+				cacheCloser = closer
+			}
+			if cleaner, ok := sqliteCache.(cacheWithCleanup); ok {
+				cacheCleaner = cleaner
+			}
+			log.Printf("Using persistent cache: %s", cfg.CacheDBPath)
+		} else {
+			log.Printf("Warning: Failed to initialize SQLite cache: %v", cacheErr)
+			log.Println("Falling back to in-memory cache")
 		}
-		cacheRepo = sqliteCache
-		if closer, ok := sqliteCache.(io.Closer); ok {
-			cacheCloser = closer
-		}
-		if cleaner, ok := sqliteCache.(cacheWithCleanup); ok {
-			cacheCleaner = cleaner
-		}
-		log.Printf("Using persistent cache: %s", cfg.CacheDBPath)
-	} else {
+	}
+
+	if cacheRepo == nil {
 		cacheRepo = storage.NewMemoryCacheRepository()
 		log.Println("Using in-memory cache (data will not persist across restarts)")
 		if !cfg.FirstRunLatestOnly {
@@ -82,10 +87,11 @@ func main() {
 	})
 	if err != nil {
 		log.Printf("Warning: LLM summarizer initialization failed: %v", err)
-		log.Println("Continuing without summarization feature...")
+		log.Println("Attempting fallback to noop summarizer...")
 		summarizerRepo, err = llm.NewSummarizerRepository(ctx, llm.Config{Provider: "noop"})
 		if err != nil {
-			log.Fatal("Failed to create fallback noop summarizer:", err)
+			log.Printf("Warning: noop summarizer initialization failed: %v", err)
+			log.Println("Continuing without summarization feature")
 		}
 	}
 


### PR DESCRIPTION
処理停止の境界を明確化します。
LLM要約機能が正常に機能しない場合はFatalで終了していましたが、Fatalで異常終了させるとフォールバック後の処理が正常に動作しなくなるので、フォールバックで担保しつつ、エラーはログに出すことに留めて処理を継続するようにします。

併せて早期リターンでなるべく処理をセクションごとに分けておきます。